### PR TITLE
customize cookie to match vercel requirements

### DIFF
--- a/app/auth/oauth2.ts
+++ b/app/auth/oauth2.ts
@@ -83,8 +83,13 @@ async function storeUserInDatabaseIfNotExists(user: User) {
 
 export const googleStrategy = new OAuth2Strategy(
     {
-        cookie: "oauth2", // Optional, can also be an object with more options
-
+        cookie: {
+            name: "oauth2",
+            secure: process.env.NODE_ENV === "production" ? true : undefined,
+            maxAge: 60 * 60 * 24 * 7, // 1 week
+            sameSite: "Lax",
+            httpOnly: true,
+        },
         clientId: process.env.GOOGLE_CLIENT_ID!,
         clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
 
@@ -135,7 +140,13 @@ export const googleStrategy = new OAuth2Strategy(
 
 export const githubStrategy = new OAuth2Strategy(
     {
-        cookie: "oauth2", // Optional, can also be an object with more options
+        cookie: {
+            name: "oauth2",
+            secure: process.env.NODE_ENV === "production" ? true : undefined,
+            maxAge: 60 * 60 * 24 * 7, // 1 week
+            sameSite: "Lax",
+            httpOnly: true,
+        },
 
         clientId: process.env.GITHUB_CLIENT_ID!,
         clientSecret: process.env.GITHUB_CLIENT_SECRET!,


### PR DESCRIPTION
### TL;DR
Enhanced OAuth2 cookie security settings for Google and GitHub authentication strategies.

### What changed?
- Replaced basic cookie configuration with detailed security settings for both Google and GitHub OAuth2 strategies
- Added secure flag for production environments
- Set cookie max age to 1 week
- Enabled sameSite "Lax" protection
- Implemented httpOnly flag to prevent client-side access

### How to test?
1. Test OAuth login flow in development environment with Google and GitHub
2. Verify cookies are being set with correct parameters
3. Confirm cookie persistence for 1 week
4. Deploy to production and verify secure flag is enabled
5. Attempt to access cookie via JavaScript to confirm httpOnly protection

### Why make this change?
To improve security of the authentication system by implementing cookie hardening measures that protect against common web vulnerabilities like XSS and CSRF attacks. These changes align with modern security best practices for handling authentication cookies.