### PR TITLE
add base URL from env to avoid any changes in future

### DIFF
--- a/app/auth/oauth2.ts
+++ b/app/auth/oauth2.ts
@@ -13,7 +13,7 @@ import { providersTable } from "~/db/schema/provider";
 
 const BASE_URL =
     process.env.NODE_ENV === "production"
-        ? "https://explorer-five-liard.vercel.app"
+        ? process.env.BASE_URL
         : "http://localhost:5173";
 
 async function getUser(email: string, loginProvider: string) {


### PR DESCRIPTION
### TL;DR
Updated production BASE_URL to use environment variable instead of hardcoded value

### What changed?
Replaced the hardcoded production URL `https://explorer-five-liard.vercel.app` with a dynamic `process.env.BASE_URL` value in the OAuth2 configuration

### How to test?
1. Set BASE_URL environment variable in production environment
2. Verify OAuth2 authentication flows work correctly
3. Confirm authentication redirects to the correct BASE_URL

### Why make this change?
Using an environment variable for the BASE_URL allows for more flexibility in deployment configurations and prevents the need to modify code when the production URL changes. This is especially important for maintaining different environments and ensuring proper OAuth2 redirect flows.