### PR TITLE
import more dependencies for Vercel deployment

### DIFF
--- a/app/util/util.server.ts
+++ b/app/util/util.server.ts
@@ -10,7 +10,24 @@ import puppeteer from "puppeteer-extra";
 import StealthPlugin from "puppeteer-extra-plugin-stealth";
 import type { Page } from "puppeteer";
 
+// All of these are imported because of a stupid thing with Vercel deployment
+// https://github.com/vercel/pkg/issues/910
 import "puppeteer-extra-plugin-stealth/evasions/chrome.app";
+import "puppeteer-extra-plugin-stealth/evasions/chrome.csi";
+import "puppeteer-extra-plugin-stealth/evasions/chrome.loadTimes";
+import "puppeteer-extra-plugin-stealth/evasions/chrome.runtime";
+import "puppeteer-extra-plugin-stealth/evasions/iframe.contentWindow";
+import "puppeteer-extra-plugin-stealth/evasions/media.codecs";
+import "puppeteer-extra-plugin-stealth/evasions/navigator.hardwareConcurrency";
+import "puppeteer-extra-plugin-stealth/evasions/navigator.languages";
+import "puppeteer-extra-plugin-stealth/evasions/navigator.permissions";
+import "puppeteer-extra-plugin-stealth/evasions/navigator.plugins";
+import "puppeteer-extra-plugin-stealth/evasions/navigator.vendor";
+import "puppeteer-extra-plugin-stealth/evasions/navigator.webdriver";
+import "puppeteer-extra-plugin-stealth/evasions/sourceurl";
+import "puppeteer-extra-plugin-stealth/evasions/user-agent-override";
+import "puppeteer-extra-plugin-stealth/evasions/webgl.vendor";
+import "puppeteer-extra-plugin-stealth/evasions/window.outerdimensions";
 
 // This is required to avoid detection by some websites
 puppeteer.use(StealthPlugin());


### PR DESCRIPTION
### TL;DR
Added missing puppeteer-extra-plugin-stealth evasion imports to fix Vercel deployment issues.

### What changed?
Added explicit imports for all puppeteer-extra-plugin-stealth evasion modules to address a known issue with Vercel deployments (issue #910).

### How to test?
1. Deploy the application to Vercel
2. Verify that puppeteer functionality works as expected
3. Check that browser automation remains undetected on target websites

### Why make this change?
Vercel deployments were failing due to missing evasion module imports. This change explicitly imports all required stealth plugin evasions to ensure proper functionality in the production environment. The fix is based on a documented issue in the Vercel pkg repository.
