### PR TITLE
add one more dependency

### DIFF
--- a/app/util/util.server.ts
+++ b/app/util/util.server.ts
@@ -28,6 +28,7 @@ import "puppeteer-extra-plugin-stealth/evasions/sourceurl";
 import "puppeteer-extra-plugin-stealth/evasions/user-agent-override";
 import "puppeteer-extra-plugin-stealth/evasions/webgl.vendor";
 import "puppeteer-extra-plugin-stealth/evasions/window.outerdimensions";
+import "puppeteer-extra-plugin-stealth/evasions/defaultArgs";
 
 // This is required to avoid detection by some websites
 puppeteer.use(StealthPlugin());


### PR DESCRIPTION
### TL;DR
Added defaultArgs evasion to puppeteer-extra-plugin-stealth imports

### What changed?
Added import for `defaultArgs` evasion from puppeteer-extra-plugin-stealth package

### How to test?
1. Run automated browser tests to ensure they continue functioning
2. Verify that web scraping operations work without being detected as automated traffic

### Why make this change?
The defaultArgs evasion helps prevent detection of automated browser activity by websites by masking default Puppeteer launch arguments. This enhances the stealth capabilities of the automation system.