### PR TITLE
add two more dependencies for vercel

### DIFF
--- a/app/util/util.server.ts
+++ b/app/util/util.server.ts
@@ -29,6 +29,8 @@ import "puppeteer-extra-plugin-stealth/evasions/user-agent-override";
 import "puppeteer-extra-plugin-stealth/evasions/webgl.vendor";
 import "puppeteer-extra-plugin-stealth/evasions/window.outerdimensions";
 import "puppeteer-extra-plugin-stealth/evasions/defaultArgs";
+import "puppeteer-extra-plugin-user-preferences";
+import "puppeteer-extra-plugin-user-data-dir";
 
 // This is required to avoid detection by some websites
 puppeteer.use(StealthPlugin());

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,8 @@
                 "puppeteer-core": "^23.11.1",
                 "puppeteer-extra": "^3.3.6",
                 "puppeteer-extra-plugin-stealth": "^2.11.2",
+                "puppeteer-extra-plugin-user-data-dir": "^2.4.1",
+                "puppeteer-extra-plugin-user-preferences": "^2.4.1",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "react-hook-form": "^7.54.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
         "puppeteer-core": "^23.11.1",
         "puppeteer-extra": "^3.3.6",
         "puppeteer-extra-plugin-stealth": "^2.11.2",
+        "puppeteer-extra-plugin-user-data-dir": "^2.4.1",
+        "puppeteer-extra-plugin-user-preferences": "^2.4.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.54.2",


### PR DESCRIPTION
### TL;DR
Added two new Puppeteer plugins for enhanced browser automation capabilities.

### What changed?
- Added `puppeteer-extra-plugin-user-preferences` plugin
- Added `puppeteer-extra-plugin-user-data-dir` plugin
- Imported both plugins in the server utility file

### How to test?
1. Run `npm install` to install the new dependencies
2. Verify that browser automation features continue to work as expected
3. Confirm no browser detection issues occur during automated tasks

### Why make this change?
These plugins provide additional browser customization options and persistence capabilities, helping to:
- Maintain consistent browser preferences across sessions
- Better manage user data directories
- Further enhance anti-detection measures when performing automated tasks