### PR TITLE
fix executable path for chromium

### DIFF
--- a/app/util/util.server.ts
+++ b/app/util/util.server.ts
@@ -37,9 +37,9 @@ import "puppeteer-extra-plugin-user-preferences";
 // This is required to avoid detection by some websites
 puppeteer.use(StealthPlugin());
 
-chromium.setHeadlessMode = true;
-const remoteExecutablePath =
-    "https://github.com/Sparticuz/chromium/releases/download/v131.0.1/chromium-v131.0.1-pack.tar";
+// chromium.setHeadlessMode = true;
+// const remoteExecutablePath =
+//     "https://github.com/Sparticuz/chromium/releases/download/v131.0.1/chromium-v131.0.1-pack.tar";
 
 let browser: Browser;
 
@@ -206,14 +206,13 @@ async function getBrowser() {
     // https://github.com/Sparticuz/chromium/issues/186
     if (process.env.NODE_ENV === "development") {
         browser = await puppeteer.launch({
-            args: ["--no-sandbox", "--disable-setuid-sandbox"],
             headless: true,
             channel: "chrome",
         });
     } else {
         browser = await puppeteer.launch({
             args: chromeArgs,
-            executablePath: await chromium.executablePath(remoteExecutablePath),
+            executablePath: await chromium.executablePath(),
             headless: true,
         });
     }


### PR DESCRIPTION
### TL;DR
Updated Puppeteer browser configuration to use default Chromium executable path and removed unnecessary remote executable path.

### What changed?
- Commented out `chromium.setHeadlessMode` and remote executable path configuration
- Removed sandbox-related arguments from development browser launch
- Updated production browser launch to use default Chromium executable path instead of remote path

### How to test?
1. Run the application in both development and production environments
2. Verify that browser-dependent functionality works as expected
3. Confirm that Puppeteer successfully launches Chrome/Chromium in both environments

### Why make this change?
The remote executable path was causing compatibility issues, and the sandbox-related arguments were unnecessary. Using the default Chromium executable path provides better stability and compatibility across different environments.