### PR TITLE
no sandbox

### DIFF
--- a/app/util/util.server.ts
+++ b/app/util/util.server.ts
@@ -43,9 +43,13 @@ puppeteer.use(StealthPlugin());
 
 let browser: Browser;
 
+// @sparticuz/chromium has default chromeArgs to improve serverless performance, but you can add others as you deem appropriate
 const chromeArgs = [
-    // @sparticuz/chromium has default chromeArgs to improve serverless performance, but you can add others as you deem appropriate
-    "--font-render-hinting=none", // Improves font-rendering quality and spacing
+    // Improves font-rendering quality and spacing
+    "--font-render-hinting=none",
+    // Disable sandbox for serverless. TODO: need to fix this by either moving
+    // chromium to Docker or self-hosting on AWS Lambda instead of Vercel
+    "--no-sandbox",
 ];
 
 type Product = {


### PR DESCRIPTION
# Add --no-sandbox flag for serverless Chromium

https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md

> What if I don't have root access to the machine and can't install anything?
>
> You will need to run developer builds with the --no-sandbox command line flag, but be aware that this disables critical security features of Chromium and should never be used when browsing the open web.

Added `--no-sandbox` flag to allow Chromium to run in serverless environments. This is a temporary solution until we can properly sandbox Chromium either through Docker containers or by self-hosting on AWS Lambda instead of Vercel.