### PR TITLE
screenshot table

### DIFF
--- a/app/db/drizzle/0013_new-table-screenshot.sql
+++ b/app/db/drizzle/0013_new-table-screenshot.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `screenshot` (
+	`id` varchar(255) NOT NULL,
+	`url` varchar(4096) NOT NULL,
+	`screenshotUrl` varchar(4096) NOT NULL,
+	CONSTRAINT `screenshot_id` PRIMARY KEY(`id`)
+);

--- a/app/db/drizzle/meta/0013_snapshot.json
+++ b/app/db/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,302 @@
+{
+  "version": "1",
+  "dialect": "singlestore",
+  "id": "55f28a60-c172-4650-beec-901974b5fd2e",
+  "prevId": "f7827d1b-9f12-4f5b-acaa-1018d47ef8b6",
+  "tables": {
+    "item": {
+      "name": "item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('file','url','text')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "favicon_url": {
+          "name": "favicon_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(360)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(360)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "compositePrimaryKeys": {
+        "item_id": {
+          "name": "item_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "provider": {
+      "name": "provider",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "compositePrimaryKeys": {
+        "providers_id": {
+          "name": "providers_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "screenshot": {
+      "name": "screenshot",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "screenshotUrl": {
+          "name": "screenshotUrl",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "compositePrimaryKeys": {
+        "screenshot_id": {
+          "name": "screenshot_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "users_table": {
+      "name": "users_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "compositePrimaryKeys": {
+        "users_table_id": {
+          "name": "users_table_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/app/db/drizzle/meta/_journal.json
+++ b/app/db/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1735908435350,
       "tag": "0012_drop-old-thumbnail-url-column",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "1",
+      "when": 1736193692913,
+      "tag": "0013_new-table-screenshot",
+      "breakpoints": true
     }
   ]
 }

--- a/app/db/drizzle/schema.ts
+++ b/app/db/drizzle/schema.ts
@@ -1,17 +1,14 @@
 import {
-    singlestoreTable,
-    singlestoreSchema,
-    AnySingleStoreColumn,
-    primaryKey,
-    varchar,
-    text,
-    singlestoreEnum,
-    tinyint,
-    timestamp,
     date,
     json,
+    primaryKey,
+    singlestoreEnum,
+    singlestoreTable,
+    text,
+    timestamp,
+    tinyint,
+    varchar,
 } from "drizzle-orm/singlestore-core";
-import { sql } from "drizzle-orm";
 
 export const item = singlestoreTable(
     "item",
@@ -45,6 +42,16 @@ export const provider = singlestoreTable(
         updatedAt: timestamp("updated_at", { mode: "string" }).notNull(),
     },
     (table) => [primaryKey({ columns: [table.id], name: "provider_id" })]
+);
+
+export const screenshot = singlestoreTable(
+    "screenshot",
+    {
+        id: varchar({ length: 255 }).notNull(),
+        url: varchar({ length: 4096 }).notNull(),
+        screenshotUrl: varchar({ length: 4096 }).notNull(),
+    },
+    (table) => [primaryKey({ columns: [table.id], name: "screenshot_id" })]
 );
 
 export const usersTable = singlestoreTable(

--- a/app/db/schema/item.ts
+++ b/app/db/schema/item.ts
@@ -1,5 +1,4 @@
 import {
-    boolean,
     json,
     primaryKey,
     singlestoreEnum,

--- a/app/db/schema/screenshot.ts
+++ b/app/db/schema/screenshot.ts
@@ -1,0 +1,15 @@
+import {
+    primaryKey,
+    singlestoreTable,
+    varchar,
+} from "drizzle-orm/singlestore-core";
+
+export const screenshotTable = singlestoreTable(
+    "screenshot",
+    {
+        id: varchar({ length: 255 }).primaryKey(),
+        url: varchar({ length: 4096 }).notNull(),
+        screenshotUrl: varchar({ length: 4096 }).notNull(),
+    },
+    (table) => [primaryKey({ columns: [table.id], name: "screenshot_id" })]
+);

--- a/app/routes/action.one-off.tsx
+++ b/app/routes/action.one-off.tsx
@@ -1,12 +1,11 @@
-import React from "react";
+import { useFetcher, useLoaderData } from "@remix-run/react";
 import { ActionFunctionArgs, LoaderFunctionArgs } from "@vercel/remix";
 import { eq } from "drizzle-orm";
+import { Button } from "~/components/ui/button";
 import { db } from "~/db/db.server";
 import { item } from "~/db/schema/item";
-import { isURLRelative, prepareUrl } from "~/util/util.server";
-import { Button } from "~/components/ui/button";
-import { useFetcher, useLoaderData } from "@remix-run/react";
 import { requireUserSession } from "~/session";
+import { isURLRelative, prepareUrl } from "~/util/util.server";
 
 export async function loader({ request }: LoaderFunctionArgs) {
     const session = await requireUserSession(request);

--- a/app/util/util.server.ts
+++ b/app/util/util.server.ts
@@ -33,8 +33,8 @@ export async function getOGData(url: string): Promise<GetOGDataResponse> {
 
     if (isPuppeteerEnabled) {
         const response = await fetch(
-            // "https://n3hdumbu6docpxby3e2wv5cuoi0lsykn.lambda-url.ap-south-1.on.aws",
-            "https://7qv4apcznftiudu35cgrsxcuk40zmnfx.lambda-url.ap-south-1.on.aws",
+            "https://n3hdumbu6docpxby3e2wv5cuoi0lsykn.lambda-url.ap-south-1.on.aws",
+            // "https://7qv4apcznftiudu35cgrsxcuk40zmnfx.lambda-url.ap-south-1.on.aws",
             {
                 method: "POST",
                 body: JSON.stringify({

--- a/app/util/util.server.ts
+++ b/app/util/util.server.ts
@@ -3,6 +3,7 @@ import ogs from "open-graph-scraper";
 import { OgObject, OpenGraphScraperOptions } from "open-graph-scraper/types";
 import { ulid } from "ulid";
 import { db } from "~/db/db.server";
+import { screenshot } from "~/db/drizzle/schema";
 import { item as itemTable } from "~/db/schema/item";
 import { User } from "~/session";
 
@@ -12,28 +13,38 @@ type Product = {
     description: string | undefined | null;
 };
 
+type GetOGDataResponse = {
+    openGraphData: OgObject;
+    product: Product;
+    // screenshotUrl: string;
+};
+
 function isURL(url: string) {
     return url.startsWith("http://") || url.startsWith("https://");
 }
 
-export async function getOGData(
-    url: string
-): Promise<{ openGraphData: OgObject; product: Product }> {
+export async function getOGData(url: string): Promise<GetOGDataResponse> {
     const isPuppeteerEnabled = process.env.ENABLE_PUPPETEER === "true";
+
+    const screenshotUrlInDB = await db
+        .select({ screenshotUrl: screenshot.screenshotUrl })
+        .from(screenshot)
+        .where(eq(screenshot.url, url));
 
     if (isPuppeteerEnabled) {
         const response = await fetch(
-            "https://n3hdumbu6docpxby3e2wv5cuoi0lsykn.lambda-url.ap-south-1.on.aws",
+            // "https://n3hdumbu6docpxby3e2wv5cuoi0lsykn.lambda-url.ap-south-1.on.aws",
+            "https://7qv4apcznftiudu35cgrsxcuk40zmnfx.lambda-url.ap-south-1.on.aws",
             {
                 method: "POST",
                 body: JSON.stringify({
                     url,
-                    isLocal: process.env.NODE_ENV === "development",
+                    fetchScreenshot: !screenshotUrlInDB.length,
                 }),
             }
         );
 
-        const { content, product } = await response.json();
+        const { content, product, screenshotUrl } = await response.json();
 
         const options: OpenGraphScraperOptions = {
             html: content,
@@ -41,6 +52,18 @@ export async function getOGData(
         };
 
         const { result } = await ogs(options);
+
+        if (
+            !screenshotUrlInDB.length &&
+            screenshotUrl &&
+            screenshotUrl.length > 0
+        ) {
+            await db.insert(screenshot).values({
+                id: ulid(),
+                url,
+                screenshotUrl,
+            });
+        }
 
         return {
             openGraphData: result,
@@ -65,6 +88,7 @@ export async function getOGData(
     return {
         openGraphData: result,
         product: { description: null, image: null, name: null },
+        // screenshotUrl: "",
     };
 }
 
@@ -165,10 +189,10 @@ export async function storeItem(item: File | TextItem, user: User) {
                     updatedAt: new Date(),
                     lastAccessedAt: new Date(),
                     description:
-                        product.description ||
-                        ogDescription ||
-                        twitterDescription ||
-                        item.description ||
+                        product.description?.slice(0, 360) ||
+                        ogDescription?.slice(0, 360) ||
+                        twitterDescription?.slice(0, 360) ||
+                        item.description?.slice(0, 360) ||
                         "",
                     faviconUrl: prepareUrl(
                         favicon,


### PR DESCRIPTION
### TL;DR

Added a new screenshot table to store webpage screenshots and integrated screenshot capture functionality.

### What changed?

- Created a new `screenshot` table with columns for id, url, and screenshotUrl
- Added screenshot capture and storage logic in `getOGData` function
- Integrated with a new Lambda endpoint for capturing screenshots
- Added length restrictions to description fields (360 chars)
- Implemented caching to prevent duplicate screenshot captures

### How to test?

1. Run database migrations to create the new screenshot table
2. Add a URL-type item through the application
3. Verify that a screenshot is captured and stored in the database
4. Add the same URL again and confirm it reuses the existing screenshot

### Why make this change?

To improve the user experience by providing visual previews of saved webpages while optimizing performance through screenshot caching. This prevents unnecessary screenshot captures of previously visited URLs and ensures consistent visual references for saved content.