### PR TITLE
update card layout

### DIFF
--- a/app/components/ui/content-card.tsx
+++ b/app/components/ui/content-card.tsx
@@ -143,8 +143,14 @@ export const ContentCard = ({
                                         />
                                     )}
                                     {title && (
-                                        <CardTitle className="font-serif font-normal text-xl">
-                                            {title}
+                                        <CardTitle className="font-serif font-normal text-xl line-clamp-2">
+                                            {title ? (
+                                                <span
+                                                    dangerouslySetInnerHTML={{
+                                                        __html: title,
+                                                    }}
+                                                />
+                                            ) : null}
                                         </CardTitle>
                                     )}
                                 </CardHeader>

--- a/app/components/ui/masonry-grid.tsx
+++ b/app/components/ui/masonry-grid.tsx
@@ -7,7 +7,7 @@ type MasonryGridProps = {
 
 const columnsByBreakpoint = {
     default: 4,
-    sm: 1,
+    sm: 2,
     md: 2,
     lg: 3,
     "2xl": 5,
@@ -58,7 +58,7 @@ export const MasonryGrid: React.FC<MasonryGridProps> = ({ children }) => {
     }, [children, numberOfColumns]);
 
     return (
-        <div className="gap-6 columns-1 md:columns-2 lg:columns-3 xl:columns-4 min-[1920px]:columns-6 min-[2560px]:columns-8 min-[3200px]:columns-10">
+        <div className="gap-6 columns-2 lg:columns-3 xl:columns-4 min-[1920px]:columns-6 min-[2560px]:columns-8 min-[3200px]:columns-10">
             <AnimatePresence mode="popLayout">
                 {grid.map((child, index) => (
                     <div className="break-inside-avoid" key={index}>


### PR DESCRIPTION
### TL;DR

Enhanced content card display with HTML rendering support and improved responsive grid layout.

### What changed?

- Modified `ContentCard` component to render HTML content in the title using `dangerouslySetInnerHTML`
- Added `line-clamp-2` class to the card title to limit it to 2 lines
- Updated the `MasonryGrid` component's responsive behavior:
  - Changed small screen columns from 1 to 2
  - Updated the CSS class to match this change (from `columns-1` to `columns-2` for mobile)

### How to test?

1. View content cards with HTML in their titles to ensure proper rendering
2. Check that long titles are properly truncated after 2 lines
3. Test the responsive layout on small screens (mobile) to verify the 2-column layout
4. Verify the grid layout across different screen sizes to ensure proper responsiveness

### Why make this change?

This change improves the user experience by allowing HTML formatting in card titles while preventing overly long titles from breaking the layout. The responsive grid update provides a better viewing experience on small screens by showing two columns instead of one, making better use of available screen space.