### PR TITLE
feat: add file upload support from paste

### DIFF
--- a/app/components/ui/content-card.tsx
+++ b/app/components/ui/content-card.tsx
@@ -70,12 +70,26 @@ export const ContentCard = ({
                     onLoad={() => setIsLoaded(true)}
                     loading="lazy"
                 />
+                <Link
+                    to={metadata?.sunchayAssetUrl ?? ""}
+                    target="_blank"
+                    rel="noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                    className="absolute bottom-1 right-1 p-2 flex gap-2 items-center shadow-top-left bg-white dark:bg-black invisible group-hover:visible rounded-sm"
+                >
+                    {getDomainFromUrl(metadata?.sunchayAssetUrl ?? "")}
+                    <ArrowUpRight />
+                </Link>
             </CardContent>
         );
 
         dialogContent = (
             <img
-                src={metadata?.sunchayAssetUrl ?? FALLBACK_THUMBNAIL}
+                src={
+                    metadata?.sunchayAssetUrl ??
+                    metadata?.image ??
+                    FALLBACK_THUMBNAIL
+                }
                 alt={title || ""}
                 className="w-full h-auto object-cover"
                 onLoad={() => setIsLoaded(true)}

--- a/app/components/ui/input-card.tsx
+++ b/app/components/ui/input-card.tsx
@@ -118,12 +118,6 @@ export const InputCard = ({
                         onChange={(e) => {
                             setHasContent(e.target.value.length > 0);
                         }}
-                        onPaste={(e) => {
-                            // This is done because the paste event triggers a
-                            // submit on the parent form and thereby does not
-                            // allow the user to paste content
-                            e.stopPropagation();
-                        }}
                         onKeyDown={(e) => {
                             if (
                                 (isMac && e.metaKey && e.key === "Enter") ||


### PR DESCRIPTION
### TL;DR

Improved paste handling and enhanced content card UI with direct link to source.

### What changed?

- Refactored paste handling to work globally across the application
- Fixed paste behavior to properly handle different contexts:
  - When pasting files: uploads them directly
  - When pasting text in a textarea: allows normal paste behavior
  - When pasting text elsewhere: triggers an upload
- Added a direct link to the source URL on content cards that appears on hover
- Enhanced image fallback logic in dialog content to use metadata.image as a secondary option
- Removed unnecessary stopPropagation on paste events in the InputCard component
- Added proper saving of uploaded files to user items

### How to test?

1. Try pasting text while focused in the textarea - it should paste normally
2. Try pasting text anywhere else on the page - it should upload as a new item
3. Try pasting an image anywhere - it should upload as a new item
4. Hover over content cards to see the new source link in the bottom right
5. Click the link to verify it opens the source in a new tab

### Why make this change?

The previous paste implementation had issues with context awareness and didn't properly handle different paste scenarios. This change makes the paste functionality more intuitive by respecting the user's current focus context. Additionally, the content card enhancement improves user experience by providing direct access to the source material.