### PR TITLE
fix content card image

### DIFF
--- a/app/components/ui/content-card.tsx
+++ b/app/components/ui/content-card.tsx
@@ -85,11 +85,7 @@ export const ContentCard = ({
 
         dialogContent = (
             <img
-                src={
-                    metadata?.sunchayAssetUrl ??
-                    metadata?.image ??
-                    FALLBACK_THUMBNAIL
-                }
+                src={metadata?.image ?? FALLBACK_THUMBNAIL}
                 alt={title || ""}
                 className="w-full h-auto object-cover"
                 onLoad={() => setIsLoaded(true)}


### PR DESCRIPTION
### TL;DR

Simplified image source selection in ContentCard component by removing the `sunchayAssetUrl` fallback option.

### What changed?

Modified the image source logic in the ContentCard component to only use `metadata?.image` or fall back to `FALLBACK_THUMBNAIL` if the image is not available. Removed the previous fallback to `metadata?.sunchayAssetUrl`.

### How to test?

1. Navigate to pages that use the ContentCard component
2. Verify that images still display correctly
3. Test with content that has no image to ensure the fallback thumbnail appears properly

### Why make this change?

The `sunchayAssetUrl` property was likely no longer needed or was redundant in the image source selection logic. This change simplifies the code and removes an unnecessary fallback option while maintaining the essential functionality.