### PR TITLE
better metadata handling and card improvement

### DIFF
--- a/app/components/ui/content-card.tsx
+++ b/app/components/ui/content-card.tsx
@@ -116,7 +116,7 @@ export const ContentCard = ({
             </CardContent>
         );
 
-        cardLabel = <Label>{title}</Label>;
+        cardLabel = title;
 
         dialogContent = (
             <img
@@ -189,6 +189,8 @@ export const ContentCard = ({
                     )}
                 </CardHeader>
             );
+        } else {
+            cardLabel = title;
         }
 
         copyContentMenuItem = (
@@ -225,8 +227,8 @@ export const ContentCard = ({
     return (
         <ContextMenu key={id}>
             <ContextMenuTrigger>
-                <div className="break-inside-avoid mb-2 md:mb-3 lg:mb-4">
-                    <div className="relative card-container group overflow-hidden">
+                <div className="break-inside-avoid mb-2 md:mb-3 lg:mb-4 flex flex-col gap-2 items-center justify-center">
+                    <div className="relative card-container group overflow-hidden max-w-full">
                         <Dialog>
                             <DialogTrigger asChild className="cursor-pointer">
                                 <Card className="hover:border-ring transition-[border] duration-300 relative w-full">
@@ -263,6 +265,11 @@ export const ContentCard = ({
                             </DropdownMenuContent>
                         </DropdownMenu>
                     </div>
+                    {cardLabel && (
+                        <Label className="text-ellipsis whitespace-nowrap overflow-hidden text-center w-[90%] justify-self-center">
+                            {cardLabel}
+                        </Label>
+                    )}
                 </div>
             </ContextMenuTrigger>
             <ContextMenuContent>

--- a/app/components/ui/label.tsx
+++ b/app/components/ui/label.tsx
@@ -1,24 +1,24 @@
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "~/lib/utils"
+import { cn } from "~/lib/utils";
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-)
+    "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+);
 
 const Label = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
-    VariantProps<typeof labelVariants>
+    React.ElementRef<typeof LabelPrimitive.Root>,
+    React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+        VariantProps<typeof labelVariants>
 >(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root
-    ref={ref}
-    className={cn(labelVariants(), className)}
-    {...props}
-  />
-))
-Label.displayName = LabelPrimitive.Root.displayName
+    <LabelPrimitive.Root
+        ref={ref}
+        className={cn(labelVariants(), className)}
+        {...props}
+    />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
 
-export { Label }
+export { Label };


### PR DESCRIPTION
### TL;DR

Improved content card UI by moving labels below cards and enhanced URL metadata handling.

### What changed?

- Moved content card labels from inside the card to below it
- Added proper text overflow handling for labels with ellipsis and centered text
- Fixed the card container layout with flex column and proper spacing
- Improved URL metadata handling logic:
  - Made the `response` parameter optional in `saveURLInfo` function
  - Enhanced metadata extraction from URLs
  - Added proper handling for existing metadata records
  - Fixed image URL preparation for metadata
  - Improved the logic for determining content type (URL vs text)

### How to test?

1. Add content cards with long titles to verify they display properly with ellipsis
2. Test adding URLs to ensure metadata is correctly fetched and displayed
3. Verify that existing URLs update their metadata correctly
4. Check that the card layout looks consistent with labels properly aligned below cards

### Why make this change?

The previous implementation had content labels inside the cards, which could cause layout issues with long titles. Moving labels below the cards provides a cleaner UI with better text overflow handling. Additionally, the URL metadata handling needed improvements to properly store and update metadata for URLs, ensuring a more consistent user experience when saving and viewing URL content.