### PR TITLE
fix infinite polling

### DIFF
--- a/app/components/ui/content-card.tsx
+++ b/app/components/ui/content-card.tsx
@@ -266,7 +266,7 @@ export const ContentCard = ({
                         </DropdownMenu>
                     </div>
                     {cardLabel && (
-                        <Label className="text-ellipsis whitespace-nowrap overflow-hidden text-center w-[90%] justify-self-center">
+                        <Label className="text-ellipsis whitespace-nowrap overflow-hidden text-center w-[90%] justify-self-center mb-2">
                             {cardLabel}
                         </Label>
                     )}


### PR DESCRIPTION
### TL;DR

Improved polling mechanism for items and added margin to card labels.

### What changed?

- Replaced interval-based polling with timeout-based polling for better control
- Implemented proper exponential backoff strategy with a maximum limit of 30 seconds
- Added flag to prevent concurrent fetch requests
- Improved error handling and network status detection
- Added a 2px bottom margin to card labels for better spacing

### How to test?

1. Navigate to the home page and verify items are loading correctly
2. Test the polling mechanism by:
   - Switching tabs and returning to see if polling resumes
   - Disconnecting and reconnecting to the network
   - Checking the console for proper error handling
3. Verify card labels have appropriate spacing with the new bottom margin

### Why make this change?

The previous interval-based polling could lead to request stacking and inefficient resource usage. The new implementation provides better control over polling frequency, prevents concurrent requests, and handles network/visibility changes more gracefully. The added margin to card labels improves the visual appearance by providing better spacing between elements.