### PR TITLE
update usage of isRequestFromDevEnvironment flag

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -185,6 +185,8 @@ export default function Index() {
                     isFavorite: 0,
                     lastAccessedAt: null,
                     status: "pending",
+                    isRequestFromDevEnvironment:
+                        process.env.NODE_ENV === "development" ? 1 : 0,
                     metadata: {
                         author: "",
                         description: "",

--- a/app/util/util.server.ts
+++ b/app/util/util.server.ts
@@ -269,6 +269,7 @@ async function saveURLInfo(content: string, user: User, response?: Response) {
         userId: user.id,
         status: "pending",
         type: "url",
+        isRequestFromDevEnvironment: process.env.NODE_ENV === "development" ? 1 : 0,
     };
 
     let tempMetadata: Maybe<Metadata>;
@@ -407,6 +408,8 @@ async function saveURLInfo(content: string, user: User, response?: Response) {
                     .set({
                         status: "partial",
                         metadataId: existingMetadata.id,
+                        isRequestFromDevEnvironment:
+                            process.env.NODE_ENV === "development" ? 1 : 0,
                         updatedAt: new Date(),
                     })
                     .where(eq(itemTable.id, existingURLItem.id));
@@ -428,6 +431,8 @@ async function saveURLInfo(content: string, user: User, response?: Response) {
                         status: "partial",
                         metadataId: newMetadataItemID,
                         updatedAt: new Date(),
+                        isRequestFromDevEnvironment:
+                            process.env.NODE_ENV === "development" ? 1 : 0,
                     })
                     .where(eq(itemTable.id, existingURLItem.id));
 
@@ -457,6 +462,8 @@ async function saveFile(content: string, user: User, fileID?: string) {
         userId: user.id,
         type: "file",
         status: "pending",
+        isRequestFromDevEnvironment:
+            process.env.NODE_ENV === "development" ? 1 : 0,
     };
 
     return db.transaction(async (tx) => {


### PR DESCRIPTION
### TL;DR

Added environment tracking to item creation by flagging requests from development environments.

### What changed?

- Added a new field `isRequestFromDevEnvironment` to track whether items are created in a development environment
- Set this flag to `1` when `process.env.NODE_ENV === "development"`, otherwise `0`
- Implemented this flag in multiple places:
  - Initial item creation in the index route
  - URL info saving process
  - File saving process
  - Item updates during metadata processing

### How to test?

1. Run the application in development mode (`NODE_ENV=development`)
2. Create new items (URLs and files)
3. Verify in the database that these items have `isRequestFromDevEnvironment` set to `1`
4. Run the application in production mode
5. Create new items
6. Verify these items have `isRequestFromDevEnvironment` set to `0`

### Why make this change?

This change helps distinguish between items created in development versus production environments, which is useful for:
- Debugging and troubleshooting issues specific to an environment
- Filtering out test data created during development
- Analyzing usage patterns with awareness of the environment context