### PR TITLE
change type column

### DIFF
--- a/app/db/drizzle/schema.ts
+++ b/app/db/drizzle/schema.ts
@@ -3,11 +3,11 @@ import {
     singlestoreSchema,
     AnySingleStoreColumn,
     primaryKey,
-    varchar,
     text,
-    singlestoreEnum,
-    tinyint,
     timestamp,
+    varchar,
+    tinyint,
+    singlestoreEnum,
     date,
     json,
 } from "drizzle-orm/singlestore-core";
@@ -15,6 +15,37 @@ import { sql } from "drizzle-orm";
 
 export const item = singlestoreTable(
     "item",
+    {
+        content: text(),
+        createdAt: timestamp("created_at", { mode: "string" }).notNull(),
+        description: varchar({ length: 360 }),
+        id: varchar({ length: 255 }).notNull(),
+        isFavorite: tinyint("is_favorite").default(0).notNull(),
+        isRequestFromDevEnvironment: tinyint("is_request_from_dev_environment")
+            .default(0)
+            .notNull(),
+        lastAccessedAt: timestamp("last_accessed_at", { mode: "string" }),
+        metadata: json(),
+        metadataId: varchar("metadata_id", { length: 255 }),
+        status: singlestoreEnum([
+            "pending",
+            "processing",
+            "partial",
+            "completed",
+            "failed",
+        ]).notNull(),
+        tags: json(),
+        title: varchar({ length: 360 }),
+        type: varchar({ length: 255 }).notNull(),
+        updatedAt: timestamp("updated_at", { mode: "string" }).notNull(),
+        url: varchar({ length: 4096 }),
+        userId: varchar("user_id", { length: 255 }).notNull(),
+    },
+    (table) => [primaryKey({ columns: [table.id], name: "item_id" })]
+);
+
+export const oldItem = singlestoreTable(
+    "old_item",
     {
         id: varchar({ length: 255 }).notNull(),
         userId: varchar("user_id", { length: 255 }).notNull(),
@@ -37,8 +68,11 @@ export const item = singlestoreTable(
             "completed",
             "failed",
         ]).notNull(),
+        isRequestFromDevEnvironment: tinyint("is_request_from_dev_environment")
+            .default(0)
+            .notNull(),
     },
-    (table) => [primaryKey({ columns: [table.id], name: "item_id" })]
+    (table) => [primaryKey({ columns: [table.id], name: "old_item_id" })]
 );
 
 export const metadata = singlestoreTable(

--- a/app/db/schema/item.ts
+++ b/app/db/schema/item.ts
@@ -32,7 +32,7 @@ export const item = singlestoreTable(
         ]).notNull(),
         tags: json(),
         title: varchar({ length: 360 }),
-        type: singlestoreEnum(["file", "url", "text"]).notNull(),
+        type: varchar({ length: 255 }).notNull(),
         updatedAt: timestamp("updated_at", { mode: "date" }).notNull(),
         url: varchar({ length: 4096 }),
         userId: varchar("user_id", { length: 255 }).notNull(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "clsx": "^2.1.1",
                 "cross-env": "^7.0.3",
                 "dotenv": "^16.4.7",
-                "drizzle-orm": "^0.38.2",
+                "drizzle-orm": "^0.40.0",
                 "html-escaper": "^3.0.3",
                 "isbot": "^4.1.0",
                 "jwt-decode": "^4.0.0",
@@ -2902,7 +2902,7 @@
             "version": "3.9.2",
             "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.2.tgz",
             "integrity": "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@pkgjs/parseargs": {
@@ -7820,9 +7820,9 @@
             }
         },
         "node_modules/drizzle-orm": {
-            "version": "0.38.4",
-            "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.38.4.tgz",
-            "integrity": "sha512-s7/5BpLKO+WJRHspvpqTydxFob8i1vo2rEx4pY6TGY7QSMuUfWUuzaY0DIpXCkgHOo37BaFC+SJQb99dDUXT3Q==",
+            "version": "0.40.1",
+            "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.40.1.tgz",
+            "integrity": "sha512-aPNhtiJiPfm3qxz1czrnIDkfvkSdKGXYeZkpG55NPTVI186LmK2fBLMi4dsHpPHlJrZeQ92D322YFPHADBALew==",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@aws-sdk/client-rds-data": ">=3",
@@ -7838,19 +7838,18 @@
                 "@tidbcloud/serverless": "*",
                 "@types/better-sqlite3": "*",
                 "@types/pg": "*",
-                "@types/react": ">=18",
                 "@types/sql.js": "*",
                 "@vercel/postgres": ">=0.8.0",
                 "@xata.io/client": "*",
                 "better-sqlite3": ">=7",
                 "bun-types": "*",
                 "expo-sqlite": ">=14.0.0",
+                "gel": ">=2",
                 "knex": "*",
                 "kysely": "*",
                 "mysql2": ">=2",
                 "pg": ">=8",
                 "postgres": ">=3",
-                "react": ">=18",
                 "sql.js": ">=1",
                 "sqlite3": ">=5"
             },
@@ -7894,9 +7893,6 @@
                 "@types/pg": {
                     "optional": true
                 },
-                "@types/react": {
-                    "optional": true
-                },
                 "@types/sql.js": {
                     "optional": true
                 },
@@ -7915,6 +7911,9 @@
                 "expo-sqlite": {
                     "optional": true
                 },
+                "gel": {
+                    "optional": true
+                },
                 "knex": {
                     "optional": true
                 },
@@ -7931,9 +7930,6 @@
                     "optional": true
                 },
                 "prisma": {
-                    "optional": true
-                },
-                "react": {
                     "optional": true
                 },
                 "sql.js": {
@@ -9633,7 +9629,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/gel/-/gel-2.0.2.tgz",
             "integrity": "sha512-XTKpfNR9HZOw+k0Bl04nETZjuP5pypVAXsZADSdwr3EtyygTTe1RqvftU2FjGu7Tp9e576a9b/iIOxWrRBxMiQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@petamoriken/float16": "^3.8.7",
@@ -9654,7 +9650,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
             "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -9667,7 +9663,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
             "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "engines": {
                 "node": ">=16"
@@ -9677,7 +9673,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
             "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^3.1.1"
@@ -15002,7 +14998,7 @@
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
             "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "clsx": "^2.1.1",
         "cross-env": "^7.0.3",
         "dotenv": "^16.4.7",
-        "drizzle-orm": "^0.38.2",
+        "drizzle-orm": "^0.40.0",
         "html-escaper": "^3.0.3",
         "isbot": "^4.1.0",
         "jwt-decode": "^4.0.0",


### PR DESCRIPTION
### TL;DR

Updated the database schema to support more flexible item types and added a new `old_item` table for backward compatibility.

### What changed?

- Changed `item.type` from an enum (`"file", "url", "text"`) to a varchar field to allow for more flexible item types
- Reordered the schema fields in `app/db/drizzle/schema.ts` for better readability
- Added a new `old_item` table that preserves the previous schema structure
- Added `isRequestFromDevEnvironment` field to both item tables
- Updated `drizzle-orm` from version 0.38.2 to 0.40.0

### How to test?

1. Run database migrations to apply the schema changes
2. Verify that existing items are still accessible
3. Create new items with both standard and custom types
4. Confirm that the `isRequestFromDevEnvironment` flag works correctly

### Why make this change?

This change provides more flexibility in the types of items that can be stored in the database by removing the enum constraint. The addition of the `old_item` table ensures backward compatibility with existing code that might depend on the previous schema structure. The `isRequestFromDevEnvironment` flag helps distinguish between requests coming from development and production environments.